### PR TITLE
Remove unnecessary `to_i` calls in `Record#+` for `last_executed_at`

### DIFF
--- a/lib/cover_rage/record.rb
+++ b/lib/cover_rage/record.rb
@@ -25,7 +25,7 @@ module CoverRage
           if item.nil? && other.last_executed_at[index].nil? then nil
           elsif item.nil? then other.last_executed_at[index]
           elsif other.last_executed_at[index].nil? then item
-          else [item.to_i, other.last_executed_at[index].to_i].max
+          else [item, other.last_executed_at[index]].max
           end
         end
       )


### PR DESCRIPTION
# Description

I reviewed https://github.com/cardinalblue/cover_rage/commit/d7e911da5eb1930378d1cb3c4cda2cbe39e348d6 and noticed this potentially unnecessary `to_i`.

Unless I'm missing something, the `last_executed_at` values are already integers because of [`Time.now.to_i`](https://github.com/cardinalblue/cover_rage/blob/fedfd5bfc13cf1b1715f22b86102fce0eae0306f/lib/cover_rage/recorder.rb#L45).


# Test Plan

[test_sum](https://github.com/cardinalblue/cover_rage/blob/fedfd5bfc13cf1b1715f22b86102fce0eae0306f/test/test_record.rb#L117-L128) already covers this.

