### PR TITLE
fix: merge coverage records collected across Ruby 3 and Ruby 4

### DIFF
--- a/lib/cover_rage/record.rb
+++ b/lib/cover_rage/record.rb
@@ -2,15 +2,15 @@
 
 module CoverRage
   Record = Data.define(:path, :revision, :source, :execution_count, :last_executed_at) do
-    def self.merge(existing, current)
+    def self.merge(existing_records, current_records)
       records_to_save = []
-      current.each do |record|
-        found = existing.find { _1.path == record.path }
+      current_records.each do |current_record|
+        existing_record = existing_records.find { _1.path == current_record.path }
         records_to_save <<
-          if found.nil? || record.revision != found.revision
-            record
+          if existing_record.nil? || current_record.revision != existing_record.revision
+            current_record
           else
-            record + found
+            existing_record + current_record
           end
       end
       records_to_save
@@ -19,13 +19,17 @@ module CoverRage
     def +(other)
       with(
         execution_count: execution_count.map.with_index do |item, index|
-          item.nil? ? nil : item + other.execution_count[index]
+          other_item = other.execution_count[index]
+          if item.nil? && other_item.nil? then nil
+          elsif item.nil? || other_item.nil? then other_item
+          else item + other_item
+          end
         end,
         last_executed_at: last_executed_at.map.with_index do |item, index|
-          if item.nil? && other.last_executed_at[index].nil? then nil
-          elsif item.nil? then other.last_executed_at[index]
-          elsif other.last_executed_at[index].nil? then item
-          else [item, other.last_executed_at[index]].max
+          other_item = other.last_executed_at[index]
+          if item.nil? && other_item.nil? then nil
+          elsif item.nil? || other_item.nil? then other_item
+          else [item, other_item].max
           end
         end
       )

--- a/test/test_record.rb
+++ b/test/test_record.rb
@@ -127,4 +127,92 @@ class TestRecord < Minitest::Test
     assert_equal [3, nil], result.execution_count
     assert_equal [200, nil], result.last_executed_at
   end
+
+  def test_sum_uses_other_when_exactly_one_execution_count_is_nil
+    r1 = CoverRage::Record.new(
+      path: '',
+      revision: '',
+      source: '',
+      execution_count: [1, nil],
+      last_executed_at: [100, nil]
+    )
+    r2 = CoverRage::Record.new(
+      path: '',
+      revision: '',
+      source: '',
+      execution_count: [nil, 2],
+      last_executed_at: [nil, 200]
+    )
+    result = r1 + r2
+    assert_equal [nil, 2], result.execution_count
+    assert_equal [nil, 200], result.last_executed_at
+  end
+
+  def test_merge_when_current_record_measures_more_lines
+    assert_equal(
+      [
+        CoverRage::Record.new(
+          path: 'foo.rb',
+          revision: '1',
+          source: '',
+          execution_count: [3, 1],
+          last_executed_at: [200, 200]
+        )
+      ],
+      CoverRage::Record.merge(
+        [
+          CoverRage::Record.new(
+            path: 'foo.rb',
+            revision: '1',
+            source: '',
+            execution_count: [1, nil],
+            last_executed_at: [100, nil]
+          )
+        ],
+        [
+          CoverRage::Record.new(
+            path: 'foo.rb',
+            revision: '1',
+            source: '',
+            execution_count: [2, 1],
+            last_executed_at: [200, 200]
+          )
+        ]
+      )
+    )
+  end
+
+  def test_merge_when_current_record_measures_fewer_lines
+    assert_equal(
+      [
+        CoverRage::Record.new(
+          path: 'foo.rb',
+          revision: '1',
+          source: '',
+          execution_count: [3, nil],
+          last_executed_at: [200, nil]
+        )
+      ],
+      CoverRage::Record.merge(
+        [
+          CoverRage::Record.new(
+            path: 'foo.rb',
+            revision: '1',
+            source: '',
+            execution_count: [1, 1],
+            last_executed_at: [100, 100]
+          )
+        ],
+        [
+          CoverRage::Record.new(
+            path: 'foo.rb',
+            revision: '1',
+            source: '',
+            execution_count: [2, nil],
+            last_executed_at: [200, nil]
+          )
+        ]
+      )
+    )
+  end
 end


### PR DESCRIPTION
## Summary

Ruby 4 changed which lines `Coverage` measures: lines that Ruby 3 reported as `nil` (not measurable) can now carry an execution count, e.g. a literal `nil` statement. As a result, records collected under different Ruby versions disagree on which entries of `execution_count` are `nil`, and merging them raised `TypeError` (`Integer + nil`).

### Reproduction

```
λ cat main.rb
def sum(a, b)
  a + b
  nil
end

sum(1, 2)
```

Ruby 3.3.10 reports the `nil` line as not measurable:

```
11      def sum(a, b)
11        a + b
nil       nil
nil     end
nil
11      sum(1, 2)
```

Ruby 4.0.5 counts it:

```
12      def sum(a, b)
12        a + b
1         nil
nil     end
nil
12      sum(1, 2)
```

### Fix

Resolve the mismatch in favor of the incoming record:

- `Record#+` now falls back to `other`'s entry when exactly one side is `nil`.
- The merge order in `Record.merge` is flipped from `record + found` to `found + record` so the freshly collected record wins.

## Tests

Three tests added to `test/test_record.rb`, mutation-checked so that reverting either half of the fix independently makes them fail:

- `test_sum_uses_other_when_exactly_one_execution_count_is_nil` — pins the `nil`-fallback in `Record#+` (raised `TypeError` before the fix).
- `test_merge_when_current_record_measures_more_lines` — a stored Ruby-3-shaped record merged with a fresh Ruby-4-shaped one keeps the new line's count.
- `test_merge_when_current_record_measures_fewer_lines` — the reverse direction, pinning the `found + record` order flip.

Full suite passes: `TEST_REDIS_URL=redis://localhost:6379 bundle exec rake test` → 28 runs, 33 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
